### PR TITLE
fix for syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ var validationResults = LicenseKeyManager.Load<TestLicense>(signedLicense)
     .TypeNot(LicenseType.Trial)
     .ActivatesBefore(DateTime.UtcNow)
     .ExpiresAfter(DateTime.UtcNow, "License is expired")
-    .MeetsCondition(license => license.LicenseData.IssuedTo == "Some Random User",
+    .MeetsCondition(license => license.KeyData.IssuedTo == "Some Random User",
         "This license was issued to Some Random User, and you're not them!")
-    .IfExpiresBefore(DateTime.UtcNow.AddDays(7), expirationDate 
-        => Console.WriteLine("warning, license expires soon")
+    .IfExpiresBefore(DateTime.UtcNow.AddDays(7), expirationDate
+        => Console.WriteLine("warning, license expires soon"))
     .Validate();
 
 if(validationResults.HasErrors)


### PR DESCRIPTION
### Problem

One of code examples in the README.md cannot be compiled (target framework .NET 6.0):

```csharp
var validationResults = LicenseKeyManager.Load<TestLicense>(signedLicense)
    .TypeNot(LicenseType.Trial)
    .ActivatesBefore(DateTime.UtcNow)
    .ExpiresAfter(DateTime.UtcNow, "License is expired")
    .MeetsCondition(license => license.LicenseData.IssuedTo == "Some Random User",
        "This license was issued to Some Random User, and you're not them!")
    .IfExpiresBefore(DateTime.UtcNow.AddDays(7), expirationDate
        => Console.WriteLine("warning, license expires soon")
    .Validate();

```

The following errors are shown:

> 'LicenseKey<TestLicense>' does not contain a definition for 'LicenseData' and no accessible extension method 'LicenseData' accepting a first argument of type 'LicenseKey<TestLicense>' could be found (are you missing a using directive or an assembly reference?)	

> ) expected

> Operator '.' cannot be applied to operand of type 'void'

### Cause

1. In order to access the custom properties of the `TestLicense`, you must use the `KeyData` property.
2. The `IfExpiresBefore` expression requires a closing bracket

```csharp
    .MeetsCondition(license => license.KeyData.IssuedTo == "Some Random User",
        "This license was issued to Some Random User, and you're not them!")
    .IfExpiresBefore(DateTime.UtcNow.AddDays(7), expirationDate
        => Console.WriteLine("warning, license expires soon"))

```